### PR TITLE
Allow ActiveRecord version 6

### DIFF
--- a/rescue_unique_constraint.gemspec
+++ b/rescue_unique_constraint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 3.2", "< 6"
+  spec.add_dependency "activerecord", ">= 3.2", "< 7"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.5"


### PR DESCRIPTION
## Overview

Rails6 updateに際してActiveRecordのバージョンを6未満から7未満へ変更